### PR TITLE
:sparkles: Feat: 記事作成画面実装

### DIFF
--- a/blog-web/src/routes/createBlog.js
+++ b/blog-web/src/routes/createBlog.js
@@ -1,6 +1,17 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { useState } from "react";
+import { axiosInstance } from "../utils/axios.js";
 
 function CreateBlog() {
+  const [title, setTitle] = useState("");
+  const [contents, setContents] = useState("");
+  const navigate = useNavigate();
+
+  const inClick = async () => {
+    await axiosInstance.post("/blogs", { title, contents });
+    navigate("/blogs", { replace: true });
+  };
+
   return(
     <div style={{ margin: "auto", width: "1000px" }}>
       <h1>ブログ作成画面</h1>
@@ -9,6 +20,28 @@ function CreateBlog() {
       </div>
       <div>
         <Link to="/blogs">記事一覧画面</Link>
+      </div>
+
+      <h2>タイトルを入力してください</h2>
+      <div>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          style={{ width: "500px" }}
+        />
+      </div>
+
+      <h2>本文を入力してください</h2>
+      <div>
+        <textarea
+          value={contents}
+          onChange={(e) => setContents(e.target.value)}
+          style={{ width: "500px", height: "300px" }}
+        />
+      </div>
+
+      <div style={{ marginTop: "20px" }}>
+        <button onClick={inClick}>記事を作成</button>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要
《実装内容》の内容について、コードチェックをお願いします。
## 実装内容
- 記事作成画面の実装
  - `title`・`contents`の状態管理は`useState`フックを使用
  - 画面遷移の状態管理は`useNavigate`フックを使用
    - `axiosInstance.post("/blogs", { title, contents })`で《axiosのbaseURL/blogs》に`title`・`contents`を付与してpostメソッドで実行
    - `navigate("/blogs", { replace: true })`で記事一覧画面に遷移するよう実行
    - `{ replace: true }`オプションで前回の入力画面に戻れないようにしている