### PR TITLE
:zap: Add: 記事一覧画面の実装

### DIFF
--- a/blog-web/src/routes/blogs.js
+++ b/blog-web/src/routes/blogs.js
@@ -1,6 +1,18 @@
 import { Link } from "react-router-dom";
+import { useState, useEffect } from "react"
+import { axiosINstance } from "../utils/axios.js";
+
 
 function Blogs() {
+  const [blogs, setBlogs] = useState();
+  useEffect(() => {
+    const f = async () => {
+      const res = await axiosInstance.get("/blogs");
+      setBlogs(res.data);
+    };
+  f();
+  }, []);
+
   return (
     <div style={{ margin: "auto", width: "1000px" }}>
       <h1>ブログ一覧画面</h1>
@@ -9,6 +21,16 @@ function Blogs() {
       </div>
       <div>
         <Link to="/create">記事作成画面</Link>
+      </div>
+
+      <div>
+        <ul>
+          {blogs?.map((b) => (
+            <Link to ={`/blogs/${b.id}`} key={b.id}>
+              <li>{b.title}</li>
+            </Link>
+          ))}
+        </ul>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要
下記《実装内容》について、《確認内容》に沿って確認をお願いします。

## 実装内容
- 記事一覧画面の実装
  - `const res = await axiosInstance.get("/blogs")`部分でRails API (http://localhost:3010/blogs) を叩く
  - rails controllerのindexアクションによって記事情報を取得、それを`res`変数に代入
  - `setBlogs(res.data);`部分で先ほどの`res`変数に代入されている`data`を`blogs`に反映させる
    - APIを叩くことで取得したデータは配列となっている
    - そのため取得したデータから記事一覧などのDBのデータを取得するには配列から`data`要素を取得する必要がある